### PR TITLE
Upgrade to PA API 5 and chunking requests into groups of 10 

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,7 @@ io.on('connection', function(socket) {
 
         let urls = await articleScraper(url);
 
+
         sendScrapedURLCount(urls.length);
         /* The scraper returns an array of Amazon affiliate links from the user's blog article .
             This code visits each one and builds an object representing the data on the page, 
@@ -118,6 +119,7 @@ io.on('connection', function(socket) {
         };
  
         for await (const res of getBatch(commonParameters, requestParameters)) {
+            console.log(new Date());
             let data = res;
 
             for (let i = 0; i < data.ItemsResult.Items.length; i++) {

--- a/articleScraper.js
+++ b/articleScraper.js
@@ -47,64 +47,62 @@ const extractAhrefAndText = function(linkObject) {     //linkObject is: $('a', h
     return extracted;
 }
 
-const articleScraper = function (url) {
-    return new Promise((resolve, reject) => {
-        rp(url)
-            .then(function (html) {
+async function articleScraper(url) {
+    try {
+        let html = await rp(url);
+        console.log(html);
 
-                const urls = [];
+        const urls = [];
 
-                var shortenedExp = /(https?:\/\/(.+?\.)?(amzn.to)(\/[A-Za-z0-9\-\._~:\/\?#\[\]@!$&'\(\)\*\+,;\=]*)?)/;
+        var shortenedExp = /(https?:\/\/(.+?\.)?(amzn.to)(\/[A-Za-z0-9\-\._~:\/\?#\[\]@!$&'\(\)\*\+,;\=]*)?)/;
+    
+        var urlsCount = $(html).find('a').length;
+        //console.log('Found ' + urlsCount + ' URLs');
+        // we now have ALL the urls, whether they're affiliate links or not 
+        // now check each one to see if it's an affiliate link, and if it is, push it to urls 
 
-                var urlsCount = $(html).find('a').length;
-                //console.log('Found ' + urlsCount + ' URLs');
-
-                // we now have ALL the urls, whether they're affiliate links or not 
-                // now check each one to see if it's an affiliate link, and if it is, push it to urls 
-            
-                for (let i = 0; i < urlsCount; i++) {
-                    //console.log("\nEVALUATING URL #", i);
-
-                    let extracted = extractAhrefAndText($('a', html)[i]); // object with url and user-readable link text 
-
-                    // if we have an href, look for the tag or the amzn.to/ASIN format
-                    if (extracted.ahref) {
-
-                        // if it has 'tag=', we are going to assume it's an affiliate link
-                        let containsTag = extracted.ahref.includes('tag=');
-
-                        // if it does not have 'tag=', see if it is a shortened URL 
-                        let shortened = shortenedExp.test(extracted.ahref);
-
-                        /* 
-                        console.log(
-                            "URL REPORT:\n" +
-                            extracted.ahref + "\n" +
-                            '-- Shortened: ' + shortened + "\n" + 
-                            '-- Contains tag: ' + containsTag
-                            );
-                        */
-
-                        // a url gets to go into the array if it either has a tag or matches the expression 
-                        if (containsTag || shortened ) {
-                            let articleURLData = {
-                                url: extracted.ahref,
-                                urlText: extracted.urlText
-                            }
-                            urls.push(articleURLData);
-                        } else {
-                            console.log("This is not an Amazon URL:", extracted.ahref);
-                        }
-                    } else {
-                        console.log("This URL does not have an ahref property:", extracted);
-                    } 
+        for (let i = 0; i < urlsCount; i++) {
+            //console.log("\nEVALUATING URL #", i);
+            let extracted = extractAhrefAndText($('a', html)[i]); // object with url and user-readable link text 
+    
+    
+            // if we have an href, look for the tag or the amzn.to/ASIN format
+            if (extracted.ahref) {
+    
+                // if it has 'tag=', we are going to assume it's an affiliate link
+                let containsTag = extracted.ahref.includes('tag=');
+    
+                // if it does not have 'tag=', see if it is a shortened URL 
+                let shortened = shortenedExp.test(extracted.ahref);
+    
+                /*
+                console.log(
+                    "URL REPORT:\n" +
+                    extracted.ahref + "\n" +
+                    '-- Shortened: ' + shortened + "\n" +
+                    '-- Contains tag: ' + containsTag
+                    );
+                */
+                // a url gets to go into the array if it either has a tag or matches the expression 
+                if (containsTag || shortened) {
+                    let articleURLData = {
+                        url: extracted.ahref,
+                        urlText: extracted.urlText
+                    };
+                    urls.push(articleURLData);
+                } else {
+                    console.log("This is not an Amazon URL:", extracted.ahref);
                 }
-                //console.log(urls);
-                resolve(urls);
-            }).catch((err) => {
-                console.log(err);
-            });
-    });
+            } else {
+                console.log("This URL does not have an ahref property:", extracted);
+            }
+        }
+
+        return urls;
+    } catch(err) {
+        console.log("Get HTML failed", err);
+    }
+    return [];
 };
 
 module.exports = articleScraper;

--- a/articleScraper.js
+++ b/articleScraper.js
@@ -89,7 +89,7 @@ async function articleScraper(url) {
                     };
                     urls.push(articleURLData);
                 } else {
-                    console.log("This is not an Amazon URL:", extracted.ahref);
+                    //console.log("This is not an Amazon URL:", extracted.ahref);
                 }
             } else {
                 console.log("This URL does not have an ahref property:", extracted);

--- a/articleScraper.js
+++ b/articleScraper.js
@@ -50,7 +50,6 @@ const extractAhrefAndText = function(linkObject) {     //linkObject is: $('a', h
 async function articleScraper(url) {
     try {
         let html = await rp(url);
-        console.log(html);
 
         const urls = [];
 

--- a/articleScraper.js
+++ b/articleScraper.js
@@ -6,7 +6,6 @@ var fs = require('fs');
 /* 
 Takes in a blog article url (supplied by website's user) and scrapes the article for
 Amazon affiliate links. It returns an array of affiliate links to app.js.
-
 */
 
 const extractAhrefAndText = function(linkObject) {     //linkObject is: $('a', html)[i]

--- a/articleScraper.js
+++ b/articleScraper.js
@@ -48,7 +48,6 @@ const extractAhrefAndText = function(linkObject) {     //linkObject is: $('a', h
 }
 
 const articleScraper = function (url) {
-    console.log("Scraping: ", url);
     return new Promise((resolve, reject) => {
         rp(url)
             .then(function (html) {
@@ -100,7 +99,7 @@ const articleScraper = function (url) {
                         console.log("This URL does not have an ahref property:", extracted);
                     } 
                 }
-                console.log(urls);
+                //console.log(urls);
                 resolve(urls);
             }).catch((err) => {
                 console.log(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,15 @@
         "uri-js": "^4.2.2"
       }
     },
+    "amazon-paapi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/amazon-paapi/-/amazon-paapi-1.0.3.tgz",
+      "integrity": "sha512-XLALc8zQbpWCiYGpFG4NcgBNsQgggqSVJzayR74g5DkgprwmKsGebUPLfREaxjBbfyMky4bdxU5vqlThwpvhAA==",
+      "requires": {
+        "crypto-js": "^4.0.0",
+        "superagent": "^5.2.2"
+      }
+    },
     "amazon-product-api": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/amazon-product-api/-/amazon-product-api-0.4.4.tgz",
@@ -544,6 +553,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -557,6 +571,11 @@
         "gud": "^1.0.0",
         "warning": "^4.0.3"
       }
+    },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "css-select": {
       "version": "1.2.0",
@@ -1135,6 +1154,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1184,6 +1208,11 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3420,6 +3449,87 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "superagent": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
+      "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
+      }
     },
     "supports-color": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chromedriver": "^2.46.0"
   },
   "dependencies": {
+    "amazon-paapi": "^1.0.3",
     "amazon-product-api": "^0.4.4",
     "cheerio": "^1.0.0-rc.3",
     "express": "^4.17.1",


### PR DESCRIPTION
- Moved to the new Product Advertising API (v5)
- Removed loop that made an individual request for each product and chunked them into groups of 10 because the API allows for that
- Improvements to the way ASIN and url data is "cached" within the app (so that multiple requests for the same ASIN are not made)